### PR TITLE
Allow relative imports and flexibility in what the plugin folder is called

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,6 +21,10 @@ Search plugin
  ***************************************************************************/
  This script initializes the plugin, making it known to QGIS.
 """
+import sys
+import os
+
+
 def name():
     return "Gazetteer Search plugin"
 def description():
@@ -32,6 +36,9 @@ def icon():
 def qgisMinimumVersion():
     return "1.8"
 def classFactory(iface):
-    # load gazetteerSearch class from file gazetteerSearch
+    # Add the directory that this file live in to the start of sys.path
+    # so that imports can be relative and our modules have the highest priority
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    # Load gazetteerSearch class from file gazetteerSearch
     from gazetteersearch import gazetteerSearch
     return gazetteerSearch(iface)

--- a/gazetteersearch.py
+++ b/gazetteersearch.py
@@ -129,7 +129,7 @@ class gazetteerSearch:
             
     def getGazetteerModule(self, config):
         gazetteer_module = config['gazetteer']    
-        imported_gazetteer = import_module('gazetteersearch.gazetteers.%s' % gazetteer_module)
+        imported_gazetteer = import_module('gazetteers.%s' % gazetteer_module)
         return imported_gazetteer
             
     def zoomTo(self, name):


### PR DESCRIPTION
Hi Nathan,

I tried to install the plugin by cloning the git repo into`/usr/share/qgis/python/plugins/` which resulted in the plugin living in a directory called `QGIS-Gazetteer-Plugin`. When I tried to use the plugin I got an import error in QGIS due to the astun gazetteer not being found as it was looking for it in a directory called `gazetteersearch.gazetteers`.

This small change adds the plugin directory to `sys.path` allowing imports to be relative to the directory the plugin lives in and means that the directory can have any name. I've updated `gazetteersearch.py` to import the gazetteers relative to the plugin root directory.

Cheers,

Matt.
