### PR TITLE
Typo fix plus expansion on install instructions and use

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,17 +4,21 @@ Adds a gazetteer search panel to QGIS 1.8 / 2.0 which by default searches [GeoNa
 
 ## Available Gazetteers
 
-All searches are performed via a web service call. The available searches can be configured in `gazetteers/config.ini`, each gazetteer requires a corresponding set of config / logic in it's own python file in `gazetters`.
+All searches are performed via a web service call. The available searches can be configured in `gazetteers/config.ini`, each gazetteer requires a corresponding set of config / logic in it's own python file in `gazetteers`.
 
 The [qgis-gazetteer-search](https://github.com/mixedbredie/qgis-gazetteer-search) repository by [mixedbredie](https://github.com/mixedbredie) is a good choice if you'd like to roll your own search webservice such as one based on the LLPG (Local Land and Property Gazetteer) or LSG (Local Street Gazetteer) used in Great Britain.
 
 ## Installation
+
+### Manual
 
 The plugin files need to live in a directory called `gazetteersearch` inside the QGIS Python plugins directory.
 
 *Windows note:* The QGIS plugin directory should be under `C:\Documents and Settings\<Username>\.qgis2\python\plugins\` (Windows XP) or `C:\Users\<Username>\.qgis2\python\plugins\` (Windows +7).
 
 *QGIS 1.8 note:* QGIS 1.8 stores it config under a `.qgis` directory.
+
+Once the plugin is loaded in the python directory, it can be enabled from the list of installed plugins in QGIS and then accessed from the plugins menu.
 
 ### Using git
 
@@ -36,3 +40,11 @@ Yahoo place search is subject to the [Yahoo! APIs Terms of Use.](http://develope
 ### OSM Nominatim
 
 Use of the OSM Nominatim search is subject to the [Nominatim usage policy](http://wiki.openstreetmap.org/wiki/Nominatim_usage_policy). OpenStreetMap data is © OpenStreetMap contributors and available under the [Open Database Licence](www.openstreetmap.org/copyright).
+
+## Configuration
+
+### Astun Technology
+
+* Uncomment the Astun Technology Gazetteer from `gazetteers\config.ini`
+* In `gazetteers\astun.py` edit the URL (line 4) to point at your iShare Maps getdata.aspx URL. This is generally your standard iShare Web URL, ending in getdata.aspx
+* Note that installations requiring credentials for access (such as iShareGIS) are not currently compatible with the Gazetteer Plugin.


### PR DESCRIPTION
I felt the instructions on installing were a bit sparse, and that we needed a section on configuring for use with AstunLocationLookup